### PR TITLE
Set authentication cookie to SameSite: None

### DIFF
--- a/src/Traces.Web/Startup.cs
+++ b/src/Traces.Web/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;

--- a/src/Traces.Web/Startup.cs
+++ b/src/Traces.Web/Startup.cs
@@ -84,7 +84,8 @@ namespace Traces.Web
                 .AddCookie(options =>
                 {
                     options.ExpireTimeSpan = TimeSpan.FromMinutes(60);
-                    options.Cookie.Name = "apaleoautorefresh";
+                    options.Cookie.Name = "apaleo_auth";
+                    options.Cookie.SameSite = SameSiteMode.None;
                 })
                 .AddAutomaticTokenRefresh()
                 .AddOpenIdConnect("apaleo", options =>


### PR DESCRIPTION
Unfortunately, to be able to have auth cookies within iframes, SameSite needs to be set to None - see https://github.com/httpwg/http-extensions/issues/762 (and google) for details