### PR TITLE
Add minimum date to date picker and fix issue with text flickering

### DIFF
--- a/src/Traces.Web/Shared/EditTraceDialog.razor
+++ b/src/Traces.Web/Shared/EditTraceDialog.razor
@@ -17,7 +17,7 @@
     <Field>
         <FieldLabel>Due date</FieldLabel>
         <FieldBody>
-            <DateEdit @bind-Date="@EditTraceDialogVm.DueDate"/>
+            <DateEdit @bind-Date="@EditTraceDialogVm.DueDate" Min="@DateTime.Today"/>
         </FieldBody>
     </Field>
     <ModalFooter>

--- a/src/Traces.Web/Startup.cs
+++ b/src/Traces.Web/Startup.cs
@@ -48,7 +48,7 @@ namespace Traces.Web
 
             services.AddServerSideBlazor();
 
-            services.AddBlazorise()
+            services.AddBlazorise(options => { options.ChangeTextOnKeyPress = false; })
                 .AddBootstrapProviders()
                 .AddFontAwesomeIcons();
 


### PR DESCRIPTION
There was an issue when writing text too fast, it would flicker and sometimes even skip characters.

Also added the minimum date for the date picker.