### PR TITLE
Add Microsoft.AspNetCore.DataProtection.Abstractions package implicitly 

### DIFF
--- a/src/Traces.Web/Traces.Web.csproj
+++ b/src/Traces.Web/Traces.Web.csproj
@@ -18,6 +18,7 @@
       <PackageReference Include="IdentityModel" Version="4.1.1" />
       <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.1" />
       <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="3.1.1" />
+      <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="3.1.1" />
       <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.1" />
       <PackageReference Include="NLog" Version="4.6.8" />
       <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.0" />


### PR DESCRIPTION
This is a workaround because of this known issue: https://github.com/aspnet/Announcements/issues/401