### PR TITLE
Change HttpContext to AuthenticationStateProvider

### DIFF
--- a/src/Traces.Web/App.razor
+++ b/src/Traces.Web/App.razor
@@ -26,9 +26,9 @@
         }
     };
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        UserClaimValidatorService.AssertClaim(AppConstants.AccountCodeQueryParameter, ApaleoClaims.AccountCode);
-        UserClaimValidatorService.AssertClaim(AppConstants.SubjectIdQueryParameter, ApaleoClaims.SubjectId);
+        await UserClaimValidatorService.AssertClaimAsync(AppConstants.AccountCodeQueryParameter, ApaleoClaims.AccountCode);
+        await UserClaimValidatorService.AssertClaimAsync(AppConstants.SubjectIdQueryParameter, ApaleoClaims.SubjectId);
     }
 }

--- a/src/Traces.Web/Services/Apaleo/IApaleoUserClaimValidatorService.cs
+++ b/src/Traces.Web/Services/Apaleo/IApaleoUserClaimValidatorService.cs
@@ -1,7 +1,9 @@
+using System.Threading.Tasks;
+
 namespace Traces.Web.Services.Apaleo
 {
     public interface IApaleoUserClaimValidatorService
     {
-        void AssertClaim(string queryParameter, string claimType);
+        Task AssertClaimAsync(string queryParameter, string claimType);
     }
 }


### PR DESCRIPTION
relates to #91 #94 

The `HttpContext` is not available most of the time (because of websockets), use `AuthenticationStateProvider` to access the user

https://docs.microsoft.com/en-us/aspnet/core/security/blazor/?view=aspnetcore-3.1&tabs=visual-studio